### PR TITLE
Added `make update` script for Docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,11 +21,14 @@ run_skip_certbot:
 	docker run -it -v $(shell pwd)/:/source/ -p 443:443 -p 80:80 --name "py-walletconnect-bridge" py-walletconnect-bridge --skip-certbot
 
 update:
+	# remove existing image and build new one
+	docker rmi py-walletconnect-bridge
+	docker build . -t py-walletconnect-bridge --build-arg branch=$(BRANCH)
+
 	# save current state of DB and copy it to local machine
 	docker exec py-walletconnect-bridge redis-cli SAVE
 	docker cp py-walletconnect-bridge:/py-walletconnect-bridge/dump.rdb dump.rdb
-	docker container stop py-walletconnect-bridge
-	docker container rm py-walletconnect-bridge
+	docker container rm -f py-walletconnect-bridge
 	
 	# start the container with `-d` to run in background
 	docker run -it -v $(shell pwd)/:/source/ -p 443:443 -p 80:80 --name "py-walletconnect-bridge" -d py-walletconnect-bridge

--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,8 @@ update:
 	docker run -it -v $(shell pwd)/:/source/ -p 443:443 -p 80:80 --name "py-walletconnect-bridge" -d py-walletconnect-bridge
 	
 	# stop the redis server, copy the previous state and restart the server
-	docker exec py-walletconnect-bridge service redis-server stop
+	docker exec py-walletconnect-bridge redis-cli SHUTDOWN
 	docker cp dump.rdb py-walletconnect-bridge:/py-walletconnect-bridge/dump.rdb
 	docker exec py-walletconnect-bridge chown redis: /py-walletconnect-bridge/dump.rdb
-	docker exec py-walletconnect-bridge service redis-server start
+	docker exec -d py-walletconnect-bridge redis-server
 	rm dump.rdb

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # make targets for WalletConnect/py-walletconnect-bridge
 
 default:
-	echo "Available tasks: build, clean, renew, run, run_skip_certbot"
+	echo "Available tasks: build, clean, renew, run, run_skip_certbot, update"
 
 build:
 	docker build . -t py-walletconnect-bridge
@@ -13,7 +13,24 @@ renew:
 	make clean && make run
 
 run:
-	docker run -it -v $(shell pwd)/:/source/ -p 443:443 -p 80:80 py-walletconnect-bridge
+	docker run -it -v $(shell pwd)/:/source/ -p 443:443 -p 80:80 --name "py-walletconnect-bridge" py-walletconnect-bridge
 
 run_skip_certbot:
-	docker run -it -v $(shell pwd)/:/source/ -p 443:443 -p 80:80 py-walletconnect-bridge --skip-certbot
+	docker run -it -v $(shell pwd)/:/source/ -p 443:443 -p 80:80 --name "py-walletconnect-bridge" py-walletconnect-bridge --skip-certbot
+
+update:
+	# save current state of DB and copy it to local machine
+	docker exec py-walletconnect-bridge redis-cli SAVE
+	docker cp py-walletconnect-bridge:/py-walletconnect-bridge/dump.rdb dump.rdb
+	docker container stop py-walletconnect-bridge
+	docker container rm py-walletconnect-bridge
+	
+	# start the container with `-d` to run in background
+	docker run -it -v $(shell pwd)/:/source/ -p 443:443 -p 80:80 --name "py-walletconnect-bridge" -d py-walletconnect-bridge
+	
+	# stop the redis server, copy the previous state and restart the server
+	docker exec py-walletconnect-bridge service redis-server stop
+	docker cp dump.rdb py-walletconnect-bridge:/py-walletconnect-bridge/dump.rdb
+	docker exec py-walletconnect-bridge chown redis: /py-walletconnect-bridge/dump.rdb
+	docker exec py-walletconnect-bridge service redis-server start
+	rm dump.rdb


### PR DESCRIPTION
Resolves #40 

#### Description
Added `make update` script in the `Makefile` that updates the already running container. It stops the running container and replaces it with a container built using the new image created after running `make build`.
The `make run` and `make run_skip_certbot` commands are also changed to have a `--name py-walletconnect-bridge` option to make managing the containers easier. This name is used to manage the container in `make update`.

#### Tasks:
- [x] Ability to run `make build` followed by `make update` to update running container.
- [x] Ability to keep the state of the RedisDB of the running container with the new image.
- [x] Ability to use the existing SSL certificates from running `make update`.