### PR TITLE
invalidate cache when remote repository is updated

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
 RUN add-apt-repository ppa:certbot/certbot
 RUN apt-get update
 RUN apt-get install -y python-certbot-nginx
+ARG revision
 RUN git clone https://github.com/WalletConnect/py-walletconnect-bridge
 WORKDIR /py-walletconnect-bridge
 RUN git checkout ${branch}

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ setup:
 build:
 	docker build . -t py-walletconnect-bridge \
 		--build-arg branch=$(BRANCH) \
-		--build-arg revision=$(shell git ls-remote https://github.com/WalletConnect/py-walletconnect-bridge $(BRANCH) | cut -f 1)
+		--build-arg revision=$(shell git ls-remote https://github.com/WalletConnect/py-walletconnect-bridge $(BRANCH) | head -n 1 | cut -f 1)
 
 clean:
 	sudo rm -rfv ssl/certbot/*

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,9 @@ setup:
 	sed -i -e 's/bridge.mydomain.com/$(URL)/g' nginx/defaultConf && rm -rf nginx/defaultConf-e
 
 build:
-	docker build . -t py-walletconnect-bridge --build-arg branch=$(BRANCH)
+	docker build . -t py-walletconnect-bridge \
+		--build-arg branch=$(BRANCH) \
+		--build-arg revision=$(shell git ls-remote https://github.com/WalletConnect/py-walletconnect-bridge $(BRANCH) | cut -f 1)
 
 clean:
 	sudo rm -rfv ssl/certbot/*


### PR DESCRIPTION
Fixes #51.

I've added build argument for docker to invalidate cache when repository is updated. It's pre-filled from the same remote git repo that is used in Dockerfile: it leverages docker layer cache (won't rebuild if revision is same) and will rebuild if remote repo was updated (even if user haven't fetched changes locally).